### PR TITLE
fix(peer): use normalized http header key

### DIFF
--- a/provider/options.go
+++ b/provider/options.go
@@ -16,8 +16,6 @@ package provider
 
 import (
 	"go.opentelemetry.io/contrib/propagators/b3"
-	"go.opentelemetry.io/contrib/propagators/jaeger"
-	"go.opentelemetry.io/contrib/propagators/opencensus"
 	"go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -72,8 +70,6 @@ func defaultConfig() *config {
 			propagation.NewCompositeTextMapPropagator(
 				b3.New(),
 				ot.OT{},
-				jaeger.Jaeger{},
-				opencensus.Binary{},
 				propagation.Baggage{},
 				propagation.TraceContext{},
 			),

--- a/tracing/peer.go
+++ b/tracing/peer.go
@@ -16,6 +16,7 @@ package tracing
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"go.opentelemetry.io/otel/attribute"
@@ -28,15 +29,15 @@ func injectPeerServiceToMetadata(_ context.Context, attrs []attribute.KeyValue) 
 	md := make(map[string]string, 3)
 
 	if serviceName != "" {
-		md[string(semconv.ServiceNameKey)] = serviceName
+		md[semconvAttributeKeyToHTTPHeader(string(semconv.ServiceNameKey))] = serviceName
 	}
 
 	if serviceNamespace != "" {
-		md[string(semconv.ServiceNamespaceKey)] = serviceNamespace
+		md[semconvAttributeKeyToHTTPHeader(string(semconv.ServiceNamespaceKey))] = serviceNamespace
 	}
 
 	if deploymentEnv != "" {
-		md[string(semconv.DeploymentEnvironmentKey)] = deploymentEnv
+		md[semconvAttributeKeyToHTTPHeader(string(semconv.DeploymentEnvironmentKey))] = deploymentEnv
 	}
 
 	return md
@@ -45,9 +46,9 @@ func injectPeerServiceToMetadata(_ context.Context, attrs []attribute.KeyValue) 
 func extractPeerServiceAttributesFromMetadata(headers *protocol.RequestHeader) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
-	serviceName, serviceNamespace, deploymentEnv := headers.Get(string(semconv.ServiceNameKey)),
-		headers.Get(string(semconv.ServiceNamespaceKey)),
-		headers.Get(string(semconv.DeploymentEnvironmentKey))
+	serviceName, serviceNamespace, deploymentEnv := headers.Get(semconvAttributeKeyToHTTPHeader(string(semconv.ServiceNameKey))),
+		headers.Get(semconvAttributeKeyToHTTPHeader(string(semconv.ServiceNamespaceKey))),
+		headers.Get(semconvAttributeKeyToHTTPHeader(string(semconv.DeploymentEnvironmentKey)))
 
 	if serviceName != "" {
 		attrs = append(attrs, semconv.PeerServiceKey.String(serviceName))
@@ -62,4 +63,8 @@ func extractPeerServiceAttributesFromMetadata(headers *protocol.RequestHeader) [
 	}
 
 	return attrs
+}
+
+func semconvAttributeKeyToHTTPHeader(key string) string {
+	return strings.ReplaceAll(key, ".", "-")
 }


### PR DESCRIPTION
- [x] Remove default `jaeger` and `opencensus` propagation
- [x] Fix http header key：`Service.name` -> `Service-Name`

[background](https://www.modb.pro/db/421659)

![ucQJ2pPaqo](https://user-images.githubusercontent.com/19374680/177723673-83c248e2-2573-42fe-8162-140e6c420299.jpg)

![hSNCCOD1S9](https://user-images.githubusercontent.com/19374680/177723494-9f3e56f1-0b54-429b-ab6e-a7220e4b937f.jpg)


