### PR TITLE
feat(otel): support sample and trace provider configurable

### DIFF
--- a/provider/options.go
+++ b/provider/options.go
@@ -46,6 +46,8 @@ type config struct {
 	resource          *resource.Resource
 	sdkTracerProvider *sdktrace.TracerProvider
 
+	sampler sdktrace.Sampler
+
 	resourceAttributes []attribute.KeyValue
 	resourceDetectors  []resource.Detector
 
@@ -66,6 +68,7 @@ func defaultConfig() *config {
 	return &config{
 		enableTracing: true,
 		enableMetrics: true,
+		sampler:       sdktrace.AlwaysSample(),
 		textMapPropagator: propagation.NewCompositeTextMapPropagator(
 			propagation.NewCompositeTextMapPropagator(
 				b3.New(),
@@ -158,5 +161,19 @@ func WithHeaders(headers map[string]string) Option {
 func WithInsecure() Option {
 	return option(func(cfg *config) {
 		cfg.exportInsecure = true
+	})
+}
+
+// WithSampler configures sampler
+func WithSampler(sampler sdktrace.Sampler) Option {
+	return option(func(cfg *config) {
+		cfg.sampler = sampler
+	})
+}
+
+// WithSdkTracerProvider configures sdkTracerProvider
+func WithSdkTracerProvider(sdkTracerProvider *sdktrace.TracerProvider) Option {
+	return option(func(cfg *config) {
+		cfg.sdkTracerProvider = sdkTracerProvider
 	})
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -113,7 +113,7 @@ func NewOpenTelemetryProvider(opts ...Option) *otelProvider {
 		tracerProvider := cfg.sdkTracerProvider
 		if tracerProvider == nil {
 			tracerProvider = sdktrace.NewTracerProvider(
-				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+				sdktrace.WithSampler(cfg.sampler),
 				sdktrace.WithResource(res),
 				sdktrace.WithSpanProcessor(bsp),
 			)


### PR DESCRIPTION
#### What type of PR is this?
The default out-of-the-box provider provides more configurable items
- [x] sampler
- [x] sdk trace provider

#### What this PR does / why we need it (English/Chinese):

Meet users' more flexible configuration needs
满足用户更灵活的配置需求
