### PR TITLE
feat: use app.GetHandlerName replace of reflect value

### DIFF
--- a/tracing/utils.go
+++ b/tracing/utils.go
@@ -33,7 +33,11 @@ import (
 // Ref to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name
 // naming rule: $HandlerName:$FullPath
 func serverSpanNaming(c *app.RequestContext) string {
-	return c.HandlerName() + ":" + c.FullPath()
+	handlerName := app.GetHandlerName(c.Handler())
+	if handlerName == "" {
+		handlerName = c.HandlerName()
+	}
+	return handlerName + ":" + c.FullPath()
 }
 
 func clientSpanNaming(req *protocol.Request) string {


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
hertz支持使用 SetHandlerName解决使用匿名函数注册路由时 handlerName为func1的问题，但是telemetry在构建span获取handler名称的时候 使用 反射获取方法名的方式，导致handlerName始终为func1影响trace注入。

使用hertz提供的app.GetHandlerName 替换HandleName()，解决无法获取到handlerName的问题。
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:
无
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
