### PR TITLE
fix(metrics): not report status code 200 when http client returns error

### DIFF
--- a/tracing/example_test.go
+++ b/tracing/example_test.go
@@ -59,6 +59,10 @@ func TestMetricsExample(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, body)
 
+	// test client returns error
+	_, _, err = c.Get(context.Background(), nil, "http://localhost:39887/ping?foo=bar")
+	assert.NotNil(t, err)
+
 	// diff metrics
 	assert.NoError(t, testutil.GatherAndCompare(
 		registry, "testdata/hertz_request_metrics.txt",

--- a/tracing/middleware.go
+++ b/tracing/middleware.go
@@ -16,19 +16,18 @@ package tracing
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/codes"
 	"time"
-
-	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/client"
 	"github.com/cloudwego/hertz/pkg/common/adaptor"
 	"github.com/cloudwego/hertz/pkg/common/hlog"
+	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/hertz-contrib/obs-opentelemetry/tracing/internal"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"

--- a/tracing/testdata/hertz_request_metrics.txt
+++ b/tracing/testdata/hertz_request_metrics.txt
@@ -1,5 +1,6 @@
 # HELP http_client_request_count_total measures the client request count total
 # TYPE http_client_request_count_total counter
+http_client_request_count_total{deployment_environment="test-env",http_host="localhost:39887",http_method="GET",http_route="/ping",otel_scope_name="github.com/hertz-contrib/obs-opentelemetry",otel_scope_version="semver:0.39.0",service_name="test-server",service_namespace="test-ns",status_code="Error"} 1
 http_client_request_count_total{deployment_environment="test-env",http_host="localhost:39888",http_method="GET",http_route="/ping",http_status_code="200",otel_scope_name="github.com/hertz-contrib/obs-opentelemetry",otel_scope_version="semver:0.39.0",service_name="test-server",service_namespace="test-ns",status_code="Unset"} 1
 # HELP http_server_request_count_total measures Incoming request count total
 # TYPE http_server_request_count_total counter


### PR DESCRIPTION

#### What type of PR is this?

fix(metrics): do not report status code 200 when http client returns error
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

en: Currently, http client report metrics status code as 200 when client returns an error. 
zh: 当前在http客户端返回错误时，metrics上报的status code是200。
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
