### PR TITLE
采样率不是100%时painc

### DIFF
--- a/tracing/middleware.go
+++ b/tracing/middleware.go
@@ -83,6 +83,9 @@ func ClientMiddleware(opts ...Option) client.Middleware {
 			)
 			defer span.End()
 
+			if !span.IsRecording() {
+				return next(ctx, req, resp)
+			}
 			// inject client service resource attributes (canonical service) to meta map
 			md := injectPeerServiceToMetadata(ctx, span.(trace.ReadOnlySpan).Resource().Attributes())
 


### PR DESCRIPTION
httpclient使用tracing中间件时当采样率不是100%时会触发painc

interface conversion: trace.nonRecordingSpan is not trace.ReadOnlySpan: missing method Attributes


